### PR TITLE
fix for authentication failure on RHEL9 when sasldb file is not found

### DIFF
--- a/xoauth2_plugin.h
+++ b/xoauth2_plugin.h
@@ -101,8 +101,6 @@ int xoauth2_client_plug_init(
 #define SASL_base64_encode(in, in_len, out, out_max_len, out_len) (utils->encode64(in, in_len, out, out_max_len, out_len))
 #define SASL_base64_decode(in, in_len, out, out_max_len, out_len) (utils->decode64(in, in_len, out, out_max_len, out_len))
 
-#define SASL_AUX_OAUTH2_BEARER_TOKENS "oauth2BearerTokens"
-
 #ifdef WIN32
 #define SASLPLUGINAPI __declspec(dllexport)
 #else


### PR DESCRIPTION
On Linux systems other than RHEL9 variants, Berkeley DB is used as the default sasldb format, so even if the sasldb file does not exist, the authentication succeeded without a fatal error. However, in RHEL9 variants, Berkeley DB was removed and gdbm became the default sasldb format, and if the sasldb file did not exist, a fatal error occurred and authentication failed.